### PR TITLE
Add flushAllExpected, and wait longer for requests to arrive

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,8 @@ HttpBackend.prototype = {
                     log(`  flushed. Trying for more.`);
                     setTimeout(tryFlush, 0);
                 }
-            } else if (flushed === 0 && Date.now() < endTime) {
+            } else if ((flushed === 0 || (numToFlush && numToFlush > flushed))
+                       && Date.now() < endTime) {
                 // we may not have made the request yet, wait a generous amount of
                 // time before giving up.
                 log(`  nothing to flush yet; waiting for requests.`);


### PR DESCRIPTION
For some reason, `flush()` no longer flushes subsequent requests that arrive as a result of the initial flush - presumably because bluebird's interaction with `setTimeout` is different to q's, somehow.

This PR introduces two fixes:

* Add `flushAllExpected`, which will wait until *all* of the requests we expected have been flushed. (We'll probably want to add some more options to this method for flexibility, but we can do that later.)
* In `flush`, when a `numToFlush` is given, wait for subequent requests to arrive, rather than giving up immediately.