### PR TITLE
Try to avoid throwing exceptions from setTimeout

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,6 +104,14 @@ HttpBackend.prototype = {
         const endTime =  waitTime + Date.now();
 
         const tryFlush = function() {
+            try {
+                _tryFlush();
+            } catch (e) {
+                defer.reject(e);
+            }
+        };
+
+        const _tryFlush = function() {
             // if there's more real requests and more expected requests, flush 'em.
             log(`  trying to flush => reqs=[${self.requests}] ` +
                 `expected=[${self.expectedRequests}]`


### PR DESCRIPTION
When we throw exceptions from setTimeout, it tends to upset the whole VM; it's
cleaner if we instead reject the returned promise. Wrap the relevant code to
make that happen.