### PR TITLE
flushAllExpected: reject sensibly when no expectations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## next version
+
+ - Give a sensible rejection from `flushAllExpected` when there are no
+   expectations (previously it would throw an obscure exception)
+ 
 ## 1.1.0
 
  - Add `flushAllExpected`.


### PR DESCRIPTION
Previously, if `flushAllExpected` was called with no expectations, it would
throw an obsure "Cannot read property 'next' of null" error. Let's actually
check for that and return a sensible rejection.