### PR TITLE
Pass the whole request object to response handlers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -263,7 +263,7 @@ HttpBackend.prototype = {
 
                 let body = testResponse.body;
                 if (Object.prototype.toString.call(body) == "[object Function]") {
-                    body = body(req.path, req.data);
+                    body = body(req.path, req.data, req);
                 }
 
                 if (!testResponse.rawBody) {


### PR DESCRIPTION
For use cases which require more information about the request, such as the query string or other information.

Signed-off-by: Travis Ralston <travis@t2bot.io>