### PR TITLE
Use `debug` for debugging output

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "package.json"
     ],
     "dependencies": {
+        "debug": "^4.3.4",
         "expect": "^28.1.0"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1235,7 +1235,7 @@ core-js-compat@^3.21.0, core-js-compat@^3.22.1:
     browserslist "^4.20.3"
     semver "7.0.0"
 
-debug@^4.1.0, debug@^4.1.1:
+debug@^4.1.0, debug@^4.1.1, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==


### PR DESCRIPTION
The output from this library tends to be very noisy. By way of shutting it up a bit, and making it easier to read, switch to [`debug`](https://github.com/debug-js/debug) for output.

A few differences to point out:

 * By default, debug output is disabled. It can be enabled by setting the environment variable `DEBUG=*` (or `DEBUG=matrix-mock-request*` to avoid the debug from babel).

 * `debug` uses `process.stderr.write` rather than `console.log`, which is a win because `jest` decorates `console.log` with lots of whitespace.

 * Each call to `flush` gets its own logger and hence its own *colour* which makes it a bit easier to see what's going on when we have a couple of interleaved calls.